### PR TITLE
setting axis=2 in expand_dims throws an error

### DIFF
--- a/live_predictions.py
+++ b/live_predictions.py
@@ -29,7 +29,7 @@ class LivePredictions:
         """
         data, sampling_rate = librosa.load(self.file)
         mfccs = np.mean(librosa.feature.mfcc(y=data, sr=sampling_rate, n_mfcc=40).T, axis=0)
-        x = np.expand_dims(mfccs, axis=2)
+        x = np.expand_dims(mfccs, axis=1)
         x = np.expand_dims(x, axis=0)
         predictions = self.loaded_model.predict_classes(x)
         print( "Prediction is", " ", self.convert_class_to_emotion(predictions))


### PR DESCRIPTION
Hi! I've tried to test on those two examples from the folder and it has thrown me an error

Traceback (most recent call last):
  File "/home/user/TONE_CLASSIFICATION/Emotion-Classification-Ravdess/live_predictions.py", line 62, in <module>
    live_prediction.make_predictions()
  File "/home/user/TONE_CLASSIFICATION/Emotion-Classification-Ravdess/live_predictions.py", line 33, in make_predictions
    x = np.expand_dims(mfccs, axis=2)
  File "<__array_function__ internals>", line 6, in expand_dims
  File "/home/user/.local/lib/python3.7/site-packages/numpy/lib/shape_base.py", line 597, in expand_dims
    axis = normalize_axis_tuple(axis, out_ndim)
  File "/home/user/.local/lib/python3.7/site-packages/numpy/core/numeric.py", line 1327, in normalize_axis_tuple
    axis = tuple([normalize_axis_index(ax, ndim, argname) for ax in axis])
  File "/home/user/.local/lib/python3.7/site-packages/numpy/core/numeric.py", line 1327, in <listcomp>
    axis = tuple([normalize_axis_index(ax, ndim, argname) for ax in axis])
numpy.AxisError: axis 2 is out of bounds for array of dimension 2

But, when setting it to axis=1 it has predicted what is expected - calm and disgust w/out throwing any error